### PR TITLE
Sitemap relative priority

### DIFF
--- a/OrchidCore/src/main/java/com/eden/orchid/api/theme/pages/OrchidPage.java
+++ b/OrchidCore/src/main/java/com/eden/orchid/api/theme/pages/OrchidPage.java
@@ -11,6 +11,7 @@ import com.eden.orchid.api.options.annotations.AllOptions;
 import com.eden.orchid.api.options.annotations.Archetype;
 import com.eden.orchid.api.options.annotations.BooleanDefault;
 import com.eden.orchid.api.options.annotations.Description;
+import com.eden.orchid.api.options.annotations.FloatDefault;
 import com.eden.orchid.api.options.annotations.Option;
 import com.eden.orchid.api.options.archetypes.ConfigArchetype;
 import com.eden.orchid.api.options.archetypes.SharedConfigArchetype;
@@ -124,11 +125,11 @@ public class OrchidPage implements
     )
     protected String changeFrequency;
 
-    @Option
+    @Option @FloatDefault(0.5f)
     @Description("The importance of this page relative to the rest of the pages on your site. Should be a value " +
             "between 0 and 1."
     )
-    protected float relativePriority = .5f;
+    protected float relativePriority;
 
     // variables that control page publication
     @Option @BooleanDefault(false)

--- a/OrchidCore/src/main/java/com/eden/orchid/api/theme/pages/OrchidPage.java
+++ b/OrchidCore/src/main/java/com/eden/orchid/api/theme/pages/OrchidPage.java
@@ -128,7 +128,7 @@ public class OrchidPage implements
     @Description("The importance of this page relative to the rest of the pages on your site. Should be a value " +
             "between 0 and 1."
     )
-    protected float relativePriority;
+    protected float relativePriority = .5f;
 
     // variables that control page publication
     @Option @BooleanDefault(false)

--- a/OrchidCore/src/main/resources/sitemap.xml.peb
+++ b/OrchidCore/src/main/resources/sitemap.xml.peb
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+{#- @pebvariable name="page" type="com.eden.orchid.impl.generators.SitemapGenerator.SitemapPage" #}
 <urlset
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"

--- a/OrchidCore/src/main/resources/sitemap.xml.peb
+++ b/OrchidCore/src/main/resources/sitemap.xml.peb
@@ -3,16 +3,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
     xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {% for entry in page.entries -%}
+    {%- for entry in page.entries %}
     <url>
         <loc>{{- entry.link -}}</loc>
         <lastmod>{{- entry.lastModifiedDate|localDate('YYYY-MM-dd') -}}</lastmod>
-        {% if entry.changeFrequency is not empty -%}
+        {%- if entry.changeFrequency is not empty %}
         <changefreq>{{- entry.changeFrequency -}}</changefreq>
         {%- endif -%}
-        {% if entry.relativePriority != 0.5 -%}
+        {%- if entry.relativePriority != 0.0 %}
         <priority>{{- entry.relativePriority -}}</priority>
-        {% endif %}
+        {%- endif %}
     </url>
-    {% endfor %}
+    {%- endfor %}
 </urlset>

--- a/OrchidCore/src/main/resources/sitemap.xml.peb
+++ b/OrchidCore/src/main/resources/sitemap.xml.peb
@@ -10,7 +10,7 @@
         {% if entry.changeFrequency is not empty -%}
         <changefreq>{{- entry.changeFrequency -}}</changefreq>
         {%- endif -%}
-        {% if entry.relativePriority != 0.0 -%}
+        {% if entry.relativePriority != 0.5 -%}
         <priority>{{- entry.relativePriority -}}</priority>
         {% endif %}
     </url>

--- a/OrchidCore/src/main/resources/sitemap.xml.peb
+++ b/OrchidCore/src/main/resources/sitemap.xml.peb
@@ -10,7 +10,7 @@
         {% if entry.changeFrequency is not empty -%}
         <changefreq>{{- entry.changeFrequency -}}</changefreq>
         {%- endif -%}
-        {% if entry.changeFrequency != 0.0 -%}
+        {% if entry.relativePriority != 0.0 -%}
         <priority>{{- entry.relativePriority -}}</priority>
         {% endif %}
     </url>

--- a/OrchidCore/src/main/resources/sitemap.xml.peb
+++ b/OrchidCore/src/main/resources/sitemap.xml.peb
@@ -10,10 +10,8 @@
         <lastmod>{{- entry.lastModifiedDate|localDate('YYYY-MM-dd') -}}</lastmod>
         {%- if entry.changeFrequency is not empty %}
         <changefreq>{{- entry.changeFrequency -}}</changefreq>
-        {%- endif -%}
-        {%- if entry.relativePriority != 0.0 %}
-        <priority>{{- entry.relativePriority -}}</priority>
         {%- endif %}
+        <priority>{{- entry.relativePriority -}}</priority>
     </url>
     {%- endfor %}
 </urlset>

--- a/OrchidCore/src/main/resources/sitemapIndex.xml.peb
+++ b/OrchidCore/src/main/resources/sitemapIndex.xml.peb
@@ -3,10 +3,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
     xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {% for sitemap in page.sitemaps -%}
+    {%- for sitemap in page.sitemaps %}
     <sitemap>
         <loc>{{- sitemap.link -}}</loc>
         <lastmod>{{- sitemap.lastModifiedDate|localDate('YYYY-MM-dd') -}}</lastmod>
     </sitemap>
-    {% endfor %}
+    {%- endfor %}
 </sitemapindex>

--- a/OrchidCore/src/main/resources/sitemapIndex.xml.peb
+++ b/OrchidCore/src/main/resources/sitemapIndex.xml.peb
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+{#- @pebvariable name="page" type="com.eden.orchid.impl.generators.SitemapGenerator.SitemapIndexPage" #}
 <sitemapindex
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"


### PR DESCRIPTION
The first commit (0ba0493) fixes the bug I wanted to fix.

While I was there, I propose changing the default relativePriority to 0.5.  See rationate in the commit (d1b50a1) message.  This includes a change in behaviour, so feel free to drop if that is not desired or there are reasons to keep the currect default.

Rest of the commits (eefb486 and 5ca52df) are purely cosmetics. Feel free to drop them if not interested.

I would have written test cases for these but I didn't know how: Kotlin is still read-only for me.